### PR TITLE
Have `init_mma` initialize `epoch` to 0

### DIFF
--- a/mmapy/mma.py
+++ b/mmapy/mma.py
@@ -187,7 +187,7 @@ def init_mma(init_design_var: np.ndarray,
       low=mma_params.lower_bound.copy(),
       upp=mma_params.upper_bound.copy(),
       is_converged=False,
-      epoch=1,
+      epoch=0,
       kkt_norm=1000.,
       change_design_var=1000.,
       )


### PR DESCRIPTION
`mma.init_mma` currently initializes the epoch number to 1, which is at odds with what's done in `MMAState.new` in which `epoch` is initialized to 0.

This change fixes this discrepancy to initialize `epoch` to 0 in `init_mma`.